### PR TITLE
Feature/ch29460/add clear filters button to delete all filters

### DIFF
--- a/plugin_dialog.ui
+++ b/plugin_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>684</width>
-    <height>665</height>
+    <height>616</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -210,6 +210,13 @@ to update the possible datasets.</string>
        <widget class="QLineEdit" name="whereInput">
         <property name="placeholderText">
          <string>columnA:valueA</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QPushButton" name="clearFiltersButton">
+        <property name="text">
+         <string>Clear filters</string>
         </property>
        </widget>
       </item>

--- a/ui_methods.py
+++ b/ui_methods.py
@@ -27,6 +27,7 @@ class InputDialog(QtWidgets.QDialog):
         self.datasetListComboBox.setEditable(True)
         self.datasetListComboBox.currentIndexChanged.connect(self.updateSchemaTable)
         self.schemaTableWidget.setEditTriggers(QtWidgets.QTableWidget.NoEditTriggers)
+        self.clearFiltersButton.clicked.connect(self.clearFilters)
         self.dialogButtonBox.accepted.connect(self.importDataset)
 
         self.show()
@@ -73,6 +74,12 @@ class InputDialog(QtWidgets.QDialog):
         if not self.showFilterCheckBox.isChecked():
             QCoreApplication.processEvents()
             self.resize(750, 0)
+
+    def clearFilters(self):
+        self.selectInput.setText('')
+        self.whereInput.setText('')
+        self.orderByInput.setText('')
+        self.limitInput.setText('')
 
     def getFilePath(self):
         fileDialog = QtWidgets.QFileDialog(self)


### PR DESCRIPTION
Add button that clears filters.
When the filters UI is hidden, filters don't apply to the import.
May have solved a part of the apikey ticket https://app.clubhouse.io/opendatasoft/story/29441/issues-with-api-key).